### PR TITLE
Peripheral filter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ var board = new firmata.Board(serialPort, function (err, ok) {
 
 ```
 
-When creating the port, specify a filter in the options to narrow down which BLE device to use. The default behaviour is to use the first device found.
+When creating the port, specify a filter in the options to narrow down which BLE device to use. The default behaviour - if the `filter` parameter is not supplied - is to use the first device found.
 
 ```js
 var serialPort = new BLESerialPort({

--- a/Readme.md
+++ b/Readme.md
@@ -28,5 +28,13 @@ var board = new firmata.Board(serialPort, function (err, ok) {
 
 ```
 
+When creating the port, specify a filter in the options to narrow down which BLE device to use. The default behaviour is to use the first device found.
 
-
+```js
+var serialPort = new BLESerialPort({
+  filter:function(peripheral) {
+    // Only connects to BLE devices with local name '101'
+    return peripheral.advertisement.localName == "101";
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var debug = require('debug')('ble-serial');
 var DEFAULT_SERIAL_SERVICE = '6e400001b5a3f393e0a9e50e24dcca9e';
 var DEFAULT_TRANSMIT_CHARACTERISTIC = '6e400002b5a3f393e0a9e50e24dcca9e';
 var DEFAULT_RECEIVE_CHARACTERISTIC = '6e400003b5a3f393e0a9e50e24dcca9e';
+var DEFAULT_FILTER = function(p) { return true; };
 
 function compareUUIDs(a, b){
   a = a || '';
@@ -24,6 +25,7 @@ function BLESerialPort(options) {
   this.receiveCharacteristic = options.receiveCharacteristic || DEFAULT_RECEIVE_CHARACTERISTIC;
   this.transmitCharacteristic = options.transmitCharacteristic || DEFAULT_TRANSMIT_CHARACTERISTIC;
   this.serviceId = options.serviceId || DEFAULT_SERIAL_SERVICE;
+  this.filter = options.filter || DEFAULT_FILTER;
   this.peripheral = options.peripheral;
 
   this.buffer = null;
@@ -50,7 +52,13 @@ function BLESerialPort(options) {
 
 
     noble.on('discover', function(peripheral) {
-    // we found a peripheral, stop scanning
+      // Check whether we should ignore device
+      if (!self.filter(peripheral)) {
+        debug('filtered out: ', peripheral.advertisement);
+        return;
+      }
+      
+      // we found a peripheral, stop scanning
       noble.stopScanning();
 
       self.peripheral = peripheral;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-serial",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Virtual serial device over BLE",
   "main": "index.js",
   "repository": "git@github.com:monteslu/ble-serial.git",


### PR DESCRIPTION
Added optional 'filter' parameter to constructor to allow callee to ignore devices they don't want to connect to. The default behaviour is for the first available device to be used, as it was before.